### PR TITLE
Switch wf executor from docker to k8sapi

### DIFF
--- a/chart/orkestra/values.yaml
+++ b/chart/orkestra/values.yaml
@@ -80,9 +80,7 @@ argo:
     name: workflow-controller
     workflowNamespaces:
       - *namespace
-    containerRuntimeExecutor: docker
-    # For KinD use -
-    # containerRuntimeExecutor: k8sapi
+    containerRuntimeExecutor: k8sapi # Most Secure - https://argoproj.github.io/argo-workflows/workflow-executors/#kubernetes-api-k8sapi
 
   server:
     enabled: true


### PR DESCRIPTION
https://argoproj.github.io/argo-workflows/workflow-executors/#kubernetes-api-k8sapi
K8S API is the most secure and well tested executor as compared to
docker which requires priviledged access for docker sock

Signed-off-by: nitishm <nitishm@microsoft.com>