### PR TITLE
Add Pre-Delete Hook to Resolve HelmRepository Bug

### DIFF
--- a/chart/orkestra/templates/helmrepository.yaml
+++ b/chart/orkestra/templates/helmrepository.yaml
@@ -1,7 +1,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: HelmRepository
 metadata:
-  name: chartmuseum
+  name: {{ .Values.chartmuseum.name }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "orkestra.labels" . | nindent 4 }}

--- a/chart/orkestra/templates/hooks.yaml
+++ b/chart/orkestra/templates/hooks.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-pre-delete"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      serviceAccountName: {{ include "orkestra.serviceAccountName" . }}
+      restartPolicy: Never
+      containers:
+      - name: pre-delete-job
+        image: bitnami/kubectl:1.21
+        env:
+          - name: RELEASE_NAMESPACE
+            value: {{ .Release.Namespace }}
+        command: ["kubectl", "delete", "helmrepositories", "-n", "$(RELEASE_NAMESPACE)", "--all"]

--- a/chart/orkestra/templates/hooks.yaml
+++ b/chart/orkestra/templates/hooks.yaml
@@ -29,5 +29,5 @@ spec:
           - name: RELEASE_NAMESPACE
             value: {{ .Release.Namespace }}
           - name: HELMREPOSITORY_NAME
-            values: {{ .Values.chartmuseum.name }}
-        command: ["kubectl", "delete", "helmrepositories", "-n", "$(RELEASE_NAMESPACE)", "$(HELMREPOSITORY_NAME}"]
+            value: {{ .Values.chartmuseum.name }}
+        command: ["kubectl", "delete", "helmrepositories", "-n", "$(RELEASE_NAMESPACE)", "$(HELMREPOSITORY_NAME)"]

--- a/chart/orkestra/templates/hooks.yaml
+++ b/chart/orkestra/templates/hooks.yaml
@@ -28,4 +28,6 @@ spec:
         env:
           - name: RELEASE_NAMESPACE
             value: {{ .Release.Namespace }}
-        command: ["kubectl", "delete", "helmrepositories", "-n", "$(RELEASE_NAMESPACE)", "--all"]
+          - name: HELMREPOSITORY_NAME
+            values: {{ .Values.chartmuseum.name }}
+        command: ["kubectl", "delete", "helmrepositories", "-n", "$(RELEASE_NAMESPACE)", "$(HELMREPOSITORY_NAME}"]

--- a/chart/orkestra/values.yaml
+++ b/chart/orkestra/values.yaml
@@ -52,6 +52,7 @@ debug:
 
 # Dependency overlay values
 chartmuseum:
+  name: chartmuseum
   interval: 5m
   env:
     open:


### PR DESCRIPTION
- Added `pre-delete` hook so that the `HelmRepository` is deleted while the finalizer can still be removed before getting rid of the entire release

Closes #201 