### PR TITLE
change default concurrent workers in orkestra charts from 20 to 5

### DIFF
--- a/chart/orkestra/values.yaml
+++ b/chart/orkestra/values.yaml
@@ -88,7 +88,7 @@ argo:
     createServiceAccount: false
 
 helm-controller:
-  concurrent: 20
+  concurrent: 5
   enabled: true
   serviceAccount:
     create: false


### PR DESCRIPTION
Closes #278

Change the default concurrent workers in the orkestra charts ```values.yaml``` file from 20 to 5.