### PR TITLE
Fix generated release name for apps and subcharts

### DIFF
--- a/pkg/utils/chart.go
+++ b/pkg/utils/chart.go
@@ -1,7 +1,6 @@
 package utils
 
 func GetSubchartName(appName, scName string) string {
-	scName = TruncateString(scName, subchartNameMaxLen)
-	appName = TruncateString(GetHash(appName), DNS1123NameMaximumLength-len(scName)-1)
+	appName = TruncateString(GetHash(appName), hashedAppNameMaxLen)
 	return ConvertToDNS1123(appName + "-" + scName)
 }

--- a/pkg/utils/chart_test.go
+++ b/pkg/utils/chart_test.go
@@ -20,7 +20,7 @@ func TestGetSubchartName(t *testing.T) {
 				appName: "",
 				scName:  "",
 			},
-			want: GetHash("")[0:62] + "-",
+			want: GetHash("")[0:hashedAppNameMaxLen] + "-",
 		},
 		{
 			name: "testing empty subchart name",
@@ -28,7 +28,7 @@ func TestGetSubchartName(t *testing.T) {
 				appName: "10charhash",
 				scName:  "",
 			},
-			want: GetHash("10charhash")[0:62] + "-",
+			want: GetHash("10charhash")[0:hashedAppNameMaxLen] + "-",
 		},
 		{
 			name: "testing empty application name",
@@ -36,31 +36,23 @@ func TestGetSubchartName(t *testing.T) {
 				appName: "",
 				scName:  "myapp-name",
 			},
-			want: GetHash("")[0:52] + "-myapp-name",
+			want: GetHash("")[0:hashedAppNameMaxLen] + "-myapp-name",
 		},
 		{
-			name: "testing subchart name length < 53",
+			name: "testing subchart name length == 52",
 			args: args{
 				appName: "appHash",
-				scName:  "mychart",
+				scName:  "thisismychart-withbigname-equalto53chars000000000009",
 			},
-			want: GetHash("appHash")[0:55] + "-mychart",
+			want: GetHash("appHash")[0:hashedAppNameMaxLen] + "-thisismychart-withbigname-equalto53chars000000000009",
 		},
 		{
-			name: "testing subchart name length == 53",
-			args: args{
-				appName: "appHash",
-				scName:  "thisismychart-withbigname-equalto53chars0000000000000",
-			},
-			want: GetHash("appHash")[0:9] + "-thisismychart-withbigname-equalto53chars0000000000000",
-		},
-		{
-			name: "testing subchart name length > 53",
+			name: "testing subchart name length > 52",
 			args: args{
 				appName: "appHash",
 				scName:  "thisismychart-withbigname-greaterthan53chars0987654321abcde",
 			},
-			want: GetHash("appHash")[0:9] + "-thisismychart-withbigname-greaterthan53chars098765432",
+			want: GetHash("appHash")[0:hashedAppNameMaxLen] + "-thisismychart-withbigname-greaterthan53chars09876543",
 		},
 		{
 			name: "testing subchart name length > 63",
@@ -68,7 +60,7 @@ func TestGetSubchartName(t *testing.T) {
 				appName: "appHash",
 				scName:  "thisismyappchart-withbigname-greaterthan63chars0987654321abcde123456789",
 			},
-			want: GetHash("appHash")[0:9] + "-thisismyappchart-withbigname-greaterthan63chars098765",
+			want: GetHash("appHash")[0:hashedAppNameMaxLen] + "-thisismyappchart-withbigname-greaterthan63chars09876",
 		},
 		{
 			name: "testing DNS1123 incompatible subchart name",
@@ -76,7 +68,7 @@ func TestGetSubchartName(t *testing.T) {
 				appName: "appHash",
 				scName:  "thisismyappchart_withbigname_greaterthan63chars0987654321abcde123456789",
 			},
-			want: GetHash("appHash")[0:9] + "-thisismyappchart-withbigname-greaterthan63chars098765",
+			want: GetHash("appHash")[0:hashedAppNameMaxLen] + "-thisismyappchart-withbigname-greaterthan63chars09876",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/utils/consts.go
+++ b/pkg/utils/consts.go
@@ -5,6 +5,6 @@ const (
 	DNS1123NotAllowedChars      = "[^-a-z0-9]"
 	DNS1123NotAllowedStartChars = "^[^a-z0-9]+"
 
-	// hashedAppNameMaxLen is the maximum length of applicaiton name hash that is
+	// hashedAppNameMaxLen is the maximum length of application name hash that is
 	hashedAppNameMaxLen = 10
 )

--- a/pkg/utils/consts.go
+++ b/pkg/utils/consts.go
@@ -5,9 +5,6 @@ const (
 	DNS1123NotAllowedChars      = "[^-a-z0-9]"
 	DNS1123NotAllowedStartChars = "^[^a-z0-9]+"
 
-	// subchartNameMaxLen is the maximum length of a subchart name.
-	//
-	// The max name length limit enforced by DNS1123 is 63 chars. We reserve 10 chars
-	// for concatenating application name hash.
-	subchartNameMaxLen = 53
+	// hashedAppNameMaxLen is the maximum length of applicaiton name hash that is
+	hashedAppNameMaxLen = 10
 )


### PR DESCRIPTION
Closes #308

This is how Kubernetes name pods:
```shell
replica-set-name = <deployment-name>-<random-string>
pod-name = <replica-set-name>-<random-string>
```

Because we were only considering subchart name length when truncating application name hash, replica-set-name becomes very long when Kubernetes append random strings to deployment-name. So, the long replica-set-name is truncated by Kubernetes when naming pods. This is the reason `kgd -n bookinfo` correctly show the application name but `kgp -n bookinfo` doesn't.

This is now fixed. The maximum length of application name hash is now 10 characters.

```shell
$ kubectl get pods -n bookinfo
NAME                                        READY   STATUS    RESTARTS   AGE
a82a4dac39-details-v1-85f7fb6749-wp5sz      1/1     Running   0          9m21s
a82a4dac39-productpage-v1-59bcb6549-mzc6l   1/1     Running   0          8m4s
a82a4dac39-ratings-v1-59574455d5-sx2sf      1/1     Running   0          9m21s
a82a4dac39-reviews-v1-589d45cdcf-r8lp4      1/1     Running   0          8m45s
a82a4dac39-reviews-v2-67c697cc9f-6fld7      1/1     Running   0          8m45s
a82a4dac39-reviews-v3-58949485dc-gctmh      1/1     Running   0          8m45s
```

```shell
$ kubectl get deployments -n bookinfo
NAME                        READY   UP-TO-DATE   AVAILABLE   AGE
a82a4dac39-details-v1       1/1     1            1           9m49s
a82a4dac39-productpage-v1   1/1     1            1           8m32s
a82a4dac39-ratings-v1       1/1     1            1           9m49s
a82a4dac39-reviews-v1       1/1     1            1           9m13s
a82a4dac39-reviews-v2       1/1     1            1           9m13s
a82a4dac39-reviews-v3       1/1     1            1           9m13s
```

```shell
$ kubectl get replicaset -n bookinfo
NAME                                  DESIRED   CURRENT   READY   AGE
a82a4dac39-details-v1-85f7fb6749      1         1         1       9m58s
a82a4dac39-productpage-v1-59bcb6549   1         1         1       8m41s
a82a4dac39-ratings-v1-59574455d5      1         1         1       9m58s
a82a4dac39-reviews-v1-589d45cdcf      1         1         1       9m22s
a82a4dac39-reviews-v2-67c697cc9f      1         1         1       9m22s
a82a4dac39-reviews-v3-58949485dc      1         1         1       9m22s
```

