### PR TITLE
Remove Unused Code in Rollback

### DIFF
--- a/controllers/appgroup_controller.go
+++ b/controllers/appgroup_controller.go
@@ -5,8 +5,6 @@ package controllers
 
 import (
 	"context"
-	"fmt"
-
 	"github.com/Azure/Orkestra/pkg/helpers"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -147,7 +145,7 @@ func (r *ApplicationGroupReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	} else if shouldRemediate {
 		if lastSuccessfulSpec := appGroup.GetLastSuccessful(); lastSuccessfulSpec != nil {
-			return reconcileHelper.Rollback(ctx, patch, fmt.Errorf(""))
+			return reconcileHelper.Rollback(ctx, patch)
 		}
 		return reconcileHelper.Reverse(ctx)
 	}


### PR DESCRIPTION
- Removes a check for HelmRelease error that should already be covered by workflow step failure