### PR TITLE
Speed up local testing by priming Kind cluster's docker registry with all required images

### DIFF
--- a/.kind-cluster.yaml
+++ b/.kind-cluster.yaml
@@ -16,3 +16,7 @@ containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
     endpoint = ["http://kind-registry:5000"]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+    endpoint = ["http://kind-registry:5000"]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."quay.io"]
+    endpoint = ["http://kind-registry:5000"]

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ clean-all: kind-delete
 
 ## Run tests.
 test: install
-	go test -v ./... -coverprofile coverage.txt -timeout 25m
+	go test -v ./... -coverprofile coverage.txt -timeout 35m
 
 ## Run tests using Ginkgo.
 ginkgo-test: install

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 ## Generate manifests e.g. CRD, RBAC etc.
-manifests: controller-gen
+manifests: generate
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=chart/orkestra/crds
 

--- a/Makefile
+++ b/Makefile
@@ -24,19 +24,19 @@ all: manager
 ## Create kind cluster with local registry and prepopulate the local registry.
 setup-dev-env: kind-create prepopulate-kind-registry
 
-## Start dev environment.
+## Deploy the Orkestra helm chart (values-ci.yaml) with Orkestra controller disabled.
 dev:
 	helm upgrade --install orkestra chart/orkestra --wait --atomic -n orkestra --create-namespace --values ${CI_VALUES}
 
-## Start dev environment in debug mode.
+## Deploy the Orkestra helm chart (values-ci.yaml) with Orkestra controller enabled (in debug mode).
 debug: dev
 	go run main.go --debug --log-level ${DEBUG_LEVEL}
 
-## Cleanup any Orkestra installation.
+## Cleanup any previous Orkestra helm chart installation.
 clean:
-	helm delete orkestra -n orkestra 2>&1
+	helm delete orkestra -n orkestra 2>&1 || true
 	@rm -rf $(BIN_DIR)
-	@echo "> 🔨 Not yet fully implemented...\n"
+	@echo "> 👍 Done\n"
 
 ## Cleanup any Orkestra installation and the kind cluster with registry.
 clean-all: kind-delete

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ endif
 all: manager
 
 ## Create kind cluster with local registry and prepopulate the local registry.
-setup-dev-env: kind-create prepopulate-kind-registry
+setup: kind-create prepopulate-kind-registry
 
 ## Deploy the Orkestra helm chart (values-ci.yaml) with Orkestra controller disabled.
 dev:
@@ -32,14 +32,13 @@ dev:
 debug: dev
 	go run main.go --debug --log-level ${DEBUG_LEVEL}
 
-## Cleanup any previous Orkestra helm chart installation.
-clean:
-	helm delete orkestra -n orkestra 2>&1 || true
-	@rm -rf $(BIN_DIR)
-	@echo "> 👍 Done\n"
-
 ## Cleanup any Orkestra installation and the kind cluster with registry.
-clean-all: kind-delete
+clean: kind-delete
+	@rm -rf $(BIN_DIR)
+
+## Cleanup any previous Orkestra helm chart installation.
+clean-chart:
+	helm delete orkestra -n orkestra 2>&1 || true
 	@rm -rf $(BIN_DIR)
 
 ## Run tests.

--- a/hack/create-kind-with-registry.sh
+++ b/hack/create-kind-with-registry.sh
@@ -17,7 +17,7 @@ if [ "${running}" != 'true' ]; then
     -d --restart=always -p "127.0.0.1:${reg_port}:5000" --name "${reg_name}" \
     registry:2
 else
-  echo "> Kind Registry container already exist, moving on ..."
+  echo "> Kind Registry container already exists, moving on ..."
 fi
 
 # Create kind cluster with the local registry enabled in containerd unless it already exists

--- a/hack/create-kind-with-registry.sh
+++ b/hack/create-kind-with-registry.sh
@@ -5,31 +5,27 @@
 
 set -o errexit
 
-# If you wish to change the cluster name, reg_name or reg_port, make sure to also update
-# the following files:
-#                     teardown-kind-with-registry.sh
-#                     .kind-cluster.yaml
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-orkestra}"
 reg_name='kind-registry'
 reg_port='5000'
 
-if kind get clusters | grep -q ^"${KIND_CLUSTER_NAME}"$ ; then
-  echo "cluster already exists, moving on"
-  exit 0
-fi
-
 # Create registry container unless it already exists
 running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
 if [ "${running}" != 'true' ]; then
-  echo "> Creating kind Registry container..."
+  echo "> Creating Kind Registry container ..."
   docker run \
     -d --restart=always -p "127.0.0.1:${reg_port}:5000" --name "${reg_name}" \
     registry:2
+else
+  echo "> Kind Registry container already exist, moving on ..."
 fi
 
-# create a kind cluster with the local registry enabled in containerd
-
-kind create cluster --name "${KIND_CLUSTER_NAME}" --config=.kind-cluster.yaml
+# Create kind cluster with the local registry enabled in containerd unless it already exists
+if kind get clusters | grep -q ^"${KIND_CLUSTER_NAME}"$ ; then
+  echo "> Kind cluster already exists, moving on ..."
+else
+  kind create cluster --name "${KIND_CLUSTER_NAME}" --config=.kind-cluster.yaml
+fi
 
 # connect the registry to the cluster network
 # (the network may already be connected)

--- a/hack/prepopulate-kind-registry.sh
+++ b/hack/prepopulate-kind-registry.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -o errexit
+
+reg_name='kind-registry'
+
+# Check if kind registry container exists.
+running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+if [ "${running}" != 'true' ]; then
+  echo "> Kind Registry container ${reg_name} doesn't exist ..."
+  echo "> Stopping prepopulating kind registry ..."
+  exit 0
+fi
+
+all_images=(
+    "azureorkestra/orkestra:latest"
+    "chartmuseum/chartmuseum:v0.12.0"
+    "fluxcd/helm-controller:v0.9.0"
+    "fluxcd/source-controller:v0.10.0"
+    "quay.io/argoproj/argocli:v3.0.2"
+    "quay.io/argoproj/workflow-controller:v3.0.2"
+)
+
+# Pull, tag, and push all images to local registry.
+for image in ${all_images[@]}; do
+    echo ""
+    echo "> 🔨  Pull, tag, and push ${image}"
+    docker pull ${image}
+    docker tag ${image} localhost:5000/${image}
+    docker push localhost:5000/${image}
+done

--- a/hack/prepopulate-kind-registry.sh
+++ b/hack/prepopulate-kind-registry.sh
@@ -2,6 +2,7 @@
 
 set -o errexit
 
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-orkestra}"
 reg_name='kind-registry'
 
 # Check if kind registry container exists.
@@ -12,7 +13,7 @@ if [ "${running}" != 'true' ]; then
   exit 0
 fi
 
-all_images=(
+images_to_push=(
     "azureorkestra/orkestra:latest"
     "chartmuseum/chartmuseum:v0.12.0"
     "fluxcd/helm-controller:v0.9.0"
@@ -22,10 +23,34 @@ all_images=(
 )
 
 # Pull, tag, and push all images to local registry.
-for image in ${all_images[@]}; do
+# Docker will pull images from remote only if one is not available locally or is not upto date.
+# NOTE: We are pushing these images to local registry instead of loading to kind because
+#       these images either have tag "latest" or have the image pull policy "Always". In both of
+#       these cases, kind will pull new image even if one is available. So, we want kind to first
+#       try pulling these images from local registry, and if one is not available, pull from
+#       remote repository. 
+for image in ${images_to_push[@]}; do
     echo ""
     echo "> 🔨  Pull, tag, and push ${image}"
     docker pull ${image}
     docker tag ${image} localhost:5000/${image}
     docker push localhost:5000/${image}
+done
+
+images_to_load=(
+  "docker.io/istio/examples-bookinfo-details-v1:1.16.2"
+  "docker.io/istio/examples-bookinfo-productpage-v1:1.16.2"
+  "docker.io/istio/examples-bookinfo-ratings-v1:1.16.2"
+  "docker.io/istio/examples-bookinfo-reviews-v1:1.16.2"
+  "docker.io/datawire/aes:1.12.1"
+  "prom/statsd-exporter:v0.8.1"
+  "redis:5.0.1"
+)
+
+# Pull image if not available locally or is not upto date and then load to kind.
+for image in ${images_to_load[@]}; do
+    echo ""
+    echo "> 🔨  Pull, load to kind ${image}"
+    docker pull ${image}
+    kind load docker-image ${image} --name ${KIND_CLUSTER_NAME}
 done

--- a/hack/teardown-kind-with-registry.sh
+++ b/hack/teardown-kind-with-registry.sh
@@ -2,16 +2,18 @@
 
 set -o errexit
 
-KIND_CLUSTER_NAME='orkestra'
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-orkestra}"
 reg_name='kind-registry'
 
 # Delete registry container if it exists
 running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
 if [ "${running}" == 'true' ]; then
   cid="$(docker inspect -f '{{.ID}}' "${reg_name}")"
-  echo "> Stopping and deleting Kind Registry container..."
+  echo "> Stopping and deleting Kind Registry container ..."
   docker stop $cid >/dev/null
   docker rm $cid >/dev/null
+else
+  echo "Kind Registry doesn't exist, moving on ..."
 fi
 
 kind delete cluster --name=$KIND_CLUSTER_NAME 2>&1


### PR DESCRIPTION
Part of #225

Few changes to local dev workflow:

- `make setup`: Create kind cluster with local registry and prepopulate the local registry with required images. Also, load required images to kind node. You need to use this only once or after you run `make clean` or restart docker/kind.

- `make dev`:  Deploy the Orkestra helm chart (values-ci.yaml) with Orkestra controller disabled.

- `make debug`: Deploy the Orkestra helm chart (values-ci.yaml) with Orkestra controller enabled (in debug mode).

- `make clean-chart`: Cleanup any previous Orkestra helm chart installation. When you make any code changes, run `make clean-chart && make dev`.

- `make clean`: Cleanup any Orkestra installation and the kind cluster with registry. After running this target, you must run `make setup` before running `make dev` or `make debug`.