### PR TITLE
Bump up default executor version to v0.4.1

### DIFF
--- a/pkg/workflow/consts.go
+++ b/pkg/workflow/consts.go
@@ -15,7 +15,7 @@ const (
 
 	ExecutorName     = "executor"
 	ExecutorImage    = "azureorkestra/executor"
-	ExecutorImageTag = "v0.4.0"
+	ExecutorImageTag = "v0.4.1"
 
 	ChartMuseumName = "chartmuseum"
 


### PR DESCRIPTION
Bump up default executor version to v0.4.1

